### PR TITLE
ExecStart command bin and config file relative path is updated with build variables

### DIFF
--- a/recipes-containers/container-management/files/service.template
+++ b/recipes-containers/container-management/files/service.template
@@ -9,7 +9,7 @@ Requires=containerd.service
 Type=simple
 Environment=HOME=%h
 Environment=XDG_CONFIG_HOME=%E
-ExecStart=/usr/bin/container-management --cfg-file /etc/container-management/config.json
+ExecStart=@CM_BIN_DD@/container-management --cfg-file  @CM_CFG_DD@/container-management/config.json
 Restart=always
 TimeoutSec=300
 


### PR DESCRIPTION
The ExecStart command in service file is updated with build variable for relative binary and config path.